### PR TITLE
修复白屏 info.Style is null

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/Window/MessageBox.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Window/MessageBox.cs
@@ -340,7 +340,7 @@ namespace HandyControl.Controls
                     messageBox.ImageBrush = ResourceHelper.GetResource<Brush>(info.IconBrushKey);
                 }
 
-                messageBox.Style = info.Style;
+                if (info.Style != null) messageBox.Style = info.Style;
                 messageBox.ShowDialog();
             }));
 #else
@@ -356,7 +356,7 @@ namespace HandyControl.Controls
                     messageBox.ImageBrush = ResourceHelper.GetResource<Brush>(info.IconBrushKey);
                 }
 
-                messageBox.Style = info.Style;
+                if (info.Style != null) messageBox.Style = info.Style;
                 SystemSounds.Asterisk.Play();
                 messageBox.ShowDialog();
             });


### PR DESCRIPTION
MessageBox 自定义时，样式为空，弹出白屏