### PR TITLE
File Explorer crash NotifyIcon disappear

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/Other/NotifyIcon.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Other/NotifyIcon.cs
@@ -574,6 +574,7 @@ namespace HandyControl.Controls
             {
                 if (msg == _wmTaskbarCreated)
                 {
+                    _added = false;
                     UpdateIcon(true);
                 }
                 else


### PR DESCRIPTION
The Icon is gone, _added will be false, then add icon can be called