### PR TITLE
Fix null exception (when application shutdown with transitioning)

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/Other/TransitioningContentControl.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Other/TransitioningContentControl.cs
@@ -49,7 +49,14 @@ namespace HandyControl.Controls
         {
             if (Visibility != Visibility.Visible || _contentPresenter == null) return;
 
-            (TransitionStoryboard ?? ResourceHelper.GetResource<Storyboard>($"{TransitionMode.ToString()}Transition"))?.Begin(_contentPresenter);
+            if (TransitionStoryboard != null)
+            {
+                TransitionStoryboard.Begin(_contentPresenter);
+            }
+            else if (Application.Current != null)
+            {
+                ResourceHelper.GetResource<Storyboard>($"{TransitionMode.ToString()}Transition")?.Begin(_contentPresenter);
+            }
         }
 
         public override void OnApplyTemplate()


### PR DESCRIPTION
Fix. Null Exception.
When using "ContextMenu" with "TransitioningContentControl" and when "MenuItem" call "Application Shutdown", then the application throws a null exception, because "Application.Current" is null and fadeout animation call "ResourceHelper.GetResource".
(or fix it in ResourceHelper.GetResource)

Example:
```xaml
<hc:NotifyIcon>
    <hc:NotifyIcon.ContextMenu>
        <ContextMenu>
            <ContextMenu.Resources>
                <Style TargetType="MenuItem">
                    <Setter Property="HeaderTemplate">
                        <Setter.Value>
                            <DataTemplate>
                                <hc:TransitioningContentControl TransitionMode="Right2LeftWithFade">
                                    <TextBlock Text="{Binding}"/>
                                </hc:TransitioningContentControl>
                            </DataTemplate>
                        </Setter.Value>
                    </Setter>
                </Style>
            </ContextMenu.Resources>
            <MenuItem Command="hc:ControlCommands.ShutdownApp" Header="ShutdownApp"/>
        </ContextMenu>
    </hc:NotifyIcon.ContextMenu>
</hc:NotifyIcon>
```