### PR TITLE
Add attached property "DataGridAttach.ClickBlankUnselect".

### DIFF
--- a/src/Shared/HandyControlDemo_Shared/UserControl/Styles/DataGridDemoCtl.xaml
+++ b/src/Shared/HandyControlDemo_Shared/UserControl/Styles/DataGridDemoCtl.xaml
@@ -9,7 +9,7 @@
     <hc:TransitioningContentControl>
         <TabControl Style="{StaticResource TabControlInLine}">
             <TabItem Header="{ex:Lang Key={x:Static langs:LangKeys.Common}}">
-                <DataGrid HeadersVisibility="All" RowHeaderWidth="60" AutoGenerateColumns="False" ItemsSource="{Binding DataList}">
+                <DataGrid hc:DataGridAttach.CanUnselectRowsWithBlankArea="True" HeadersVisibility="All" RowHeaderWidth="60" AutoGenerateColumns="False" ItemsSource="{Binding DataList}">
                     <DataGrid.RowHeaderTemplate>
                         <DataTemplate>
                             <CheckBox IsChecked="{Binding IsSelected,RelativeSource={RelativeSource AncestorType=DataGridRow}}"/>

--- a/src/Shared/HandyControl_Shared/Controls/Attach/DataGridAttach.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Attach/DataGridAttach.cs
@@ -312,20 +312,21 @@ namespace HandyControl.Controls
         /// <summary>
         /// 在 <see cref="DataGrid"/> 中点击空白地方取消选择所有 Row 和 Cell
         /// </summary>
-        public static readonly DependencyProperty ClickBlankUnselectProperty =
-            DependencyProperty.RegisterAttached("ClickBlankUnselect", typeof(bool), typeof(DataGridAttach), new PropertyMetadata(false, ClickBlankUnselectPropertyChanged));
+        public static readonly DependencyProperty CanUnselectRowsWithBlankAreaProperty =
+            DependencyProperty.RegisterAttached("CanUnselectRowsWithBlankArea", typeof(bool), typeof(DataGridAttach),
+                                                new PropertyMetadata(false, OnCanUnselectRowsWithBlankAreaChanged));
 
-        public static bool GetClickBlankUnselect(DependencyObject obj)
+        public static bool GetCanUnselectRowsWithBlankArea(DependencyObject obj)
         {
-            return (bool)obj.GetValue(ClickBlankUnselectProperty);
+            return (bool)obj.GetValue(CanUnselectRowsWithBlankAreaProperty);
         }
 
-        public static void SetClickBlankUnselect(DependencyObject obj, bool value)
+        public static void SetCanUnselectRowsWithBlankArea(DependencyObject obj, bool value)
         {
-            obj.SetValue(ClickBlankUnselectProperty, value);
+            obj.SetValue(CanUnselectRowsWithBlankAreaProperty, value);
         }
 
-        public static void ClickBlankUnselectPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        public static void OnCanUnselectRowsWithBlankAreaChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             if (d is DataGrid dataGrid && e.NewValue is bool enabled)
             {
@@ -338,19 +339,10 @@ namespace HandyControl.Controls
 
         private static void DataGrid_PreviewMouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
-            if (sender is DataGrid dataGrid)
+            if (sender is DataGrid dataGrid && e.OriginalSource is System.Windows.Controls.ScrollViewer)
             {
-                var dependencyObject = e.OriginalSource as DependencyObject;
-                while (dependencyObject != null && !(dependencyObject is DataGridRow))
-                {
-                    dependencyObject = VisualTreeHelper.GetParent(dependencyObject);
-                }
-
-                if (dependencyObject == null)
-                {
-                    dataGrid.CommitEdit();
-                    dataGrid.UnselectAll();
-                }
+                dataGrid.CommitEdit();
+                dataGrid.UnselectAll();
             }
         }
     }

--- a/src/Shared/HandyControl_Shared/Controls/Attach/DataGridAttach.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Attach/DataGridAttach.cs
@@ -2,7 +2,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using System.Windows.Media;
+using System.Windows.Input;
 using HandyControl.Data;
 
 namespace HandyControl.Controls
@@ -309,35 +309,25 @@ namespace HandyControl.Controls
 
         private static void DataGrid_LoadingRow(object sender, DataGridRowEventArgs e) => e.Row.Header = (e.Row.GetIndex() + 1).ToString();
 
-        /// <summary>
-        /// 在 <see cref="DataGrid"/> 中点击空白地方取消选择所有 Row 和 Cell
-        /// </summary>
-        public static readonly DependencyProperty CanUnselectRowsWithBlankAreaProperty =
-            DependencyProperty.RegisterAttached("CanUnselectRowsWithBlankArea", typeof(bool), typeof(DataGridAttach),
-                                                new PropertyMetadata(false, OnCanUnselectRowsWithBlankAreaChanged));
+        public static readonly DependencyProperty CanUnselectAllWithBlankAreaProperty = DependencyProperty.RegisterAttached(
+            "CanUnselectAllWithBlankArea", typeof(bool), typeof(DataGridAttach), new PropertyMetadata(ValueBoxes.FalseBox, OnCanUnselectAllWithBlankAreaChanged));
 
-        public static bool GetCanUnselectRowsWithBlankArea(DependencyObject obj)
+        private static void OnCanUnselectAllWithBlankAreaChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            return (bool)obj.GetValue(CanUnselectRowsWithBlankAreaProperty);
-        }
-
-        public static void SetCanUnselectRowsWithBlankArea(DependencyObject obj, bool value)
-        {
-            obj.SetValue(CanUnselectRowsWithBlankAreaProperty, value);
-        }
-
-        public static void OnCanUnselectRowsWithBlankAreaChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            if (d is DataGrid dataGrid && e.NewValue is bool enabled)
+            if (d is DataGrid dataGrid)
             {
-                if (enabled)
+                if ((bool)e.NewValue)
+                {
                     dataGrid.PreviewMouseDown += DataGrid_PreviewMouseDown;
+                }
                 else
+                {
                     dataGrid.PreviewMouseDown -= DataGrid_PreviewMouseDown;
+                }
             }
         }
 
-        private static void DataGrid_PreviewMouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        private static void DataGrid_PreviewMouseDown(object sender, MouseButtonEventArgs e)
         {
             if (sender is DataGrid dataGrid && e.OriginalSource is System.Windows.Controls.ScrollViewer)
             {
@@ -345,5 +335,11 @@ namespace HandyControl.Controls
                 dataGrid.UnselectAll();
             }
         }
+
+        public static void SetCanUnselectAllWithBlankArea(DependencyObject element, bool value)
+            => element.SetValue(CanUnselectAllWithBlankAreaProperty, value);
+
+        public static bool GetCanUnselectAllWithBlankArea(DependencyObject element)
+            => (bool) element.GetValue(CanUnselectAllWithBlankAreaProperty);
     }
 }

--- a/src/Shared/HandyControl_Shared/Controls/Attach/DataGridAttach.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Attach/DataGridAttach.cs
@@ -313,7 +313,7 @@ namespace HandyControl.Controls
         /// 在 <see cref="DataGrid"/> 中点击空白地方取消选择所有 Row 和 Cell
         /// </summary>
         public static readonly DependencyProperty ClickBlankUnselectProperty =
-            DependencyProperty.RegisterAttached("ClickBlankUnselect", typeof(bool), typeof(DataGrid), new PropertyMetadata(false, ClickBlankUnselectPropertyChanged));
+            DependencyProperty.RegisterAttached("ClickBlankUnselect", typeof(bool), typeof(DataGridAttach), new PropertyMetadata(false, ClickBlankUnselectPropertyChanged));
 
         public static bool GetClickBlankUnselect(DependencyObject obj)
         {


### PR DESCRIPTION
Add attached property `DataGridAttach.ClickBlankUnselect` for `DataGrid`, make it able to unselect all when click blank area.

为 `DataGrid` 增加附加项属性 `DataGridAttach.ClickBlankUnselect`，在点击空白区域时能够取消选择所有项目。