### PR TITLE
每次有代码提交都自动加上构建测试

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: build
 
-on:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   build:
@@ -11,17 +8,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
-      
-      - name: Setup Nuget.exe
-        uses: nuget/setup-nuget@main
-      
-      - name: Restore Nuget packages
-        run: nuget restore src/HandyControl.sln
-
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@master
-        with:
-          dotnet-version: '5.0.100'
       
       - name: Build Net_40
         run: dotnet build src/Net_40/HandyControl_Net_40/HandyControl_Net_40.csproj -p:Configuration=Release-Net40


### PR DESCRIPTION
原先的写法是只有代码合并到 master 之后才触发构建

当前修改为只要有代码推送就触发构建，这样提的 PR 代码审查里面，将可以自动跑一次自动构建测试，至少合入的代码，在合入之前是能构建通过的

因为没有用到 NuGet 命令，使用 dotnet 自带还原了，因此可以删除 `Setup Nuget.exe` 和 `nuget restore` 的逻辑

因为使用了 `windows-latest` 因此可以删除 `Setup .NET Core` 的逻辑

删除以上两个逻辑，能让构建速度减少 10 秒以上