### PR TITLE
Fix #561

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/Input/NumericUpDown.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Input/NumericUpDown.cs
@@ -156,7 +156,7 @@ namespace HandyControl.Controls
         private string CurrentText => string.IsNullOrWhiteSpace(ValueFormat)
             ? DecimalPlaces.HasValue
                 ? Value.ToString($"#0.{new string('0', DecimalPlaces.Value)}")
-                : Value.ToString("#0")
+                : Value.ToString()
             : Value.ToString(ValueFormat);
 
         protected virtual void OnValueChanged(FunctionEventArgs<double> e) => RaiseEvent(e);


### PR DESCRIPTION
DecimalPlaces为null时，使用值的默认文本格式，以支持显示小数。