### PR TITLE
Fix Badge Zero Value

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/Other/Badge.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Other/Badge.cs
@@ -11,6 +11,11 @@ namespace HandyControl.Controls
     /// </summary>
     public class Badge : ContentControl
     {
+        public Badge()
+        {
+            OnValueChanged(this, new DependencyPropertyChangedEventArgs(ValueProperty,ValueBoxes.Int0Box, ValueBoxes.Int0Box));
+        }
+        
         public static readonly RoutedEvent ValueChangedEvent =
             EventManager.RegisterRoutedEvent("ValueChanged", RoutingStrategy.Bubble,
                 typeof(EventHandler<FunctionEventArgs<int>>), typeof(Badge));


### PR DESCRIPTION
If we set `Badge.Value = 0` , `OnValueChanged` Does not run and this is result

![1](https://user-images.githubusercontent.com/9213496/103175424-2ee8fe80-487f-11eb-8414-1bc29410b362.png)
