### PR TITLE
Update PreviewSlider Fix #726

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/Slider/PreviewSlider.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Slider/PreviewSlider.cs
@@ -93,7 +93,7 @@ namespace HandyControl.Controls
 
             if (Orientation == Orientation.Horizontal)
             {
-                var pos = (e.GetPosition(this).X - _thumb.ActualWidth / 2) / _track.ActualWidth * Maximum;
+                var pos = (e.GetPosition(this).X - _thumb.ActualWidth / 2) / _track.ActualWidth * (Maximum - Minimum) + Minimum;
                 if (pos > Maximum || pos < 0)
                 {
                     if (_thumb.IsMouseCaptureWithin)
@@ -110,7 +110,7 @@ namespace HandyControl.Controls
             }
             else
             {
-                var pos = Maximum - (e.GetPosition(this).Y - _thumb.ActualHeight / 2) / _track.ActualHeight * Maximum;
+                var pos = (1 - (e.GetPosition(this).Y - _thumb.ActualHeight / 2) / _track.ActualHeight) * (Maximum - Minimum) + Minimum;
                 if (pos > Maximum || pos < 0)
                 {
                     if (_thumb.IsMouseCaptureWithin)


### PR DESCRIPTION
修复预览滑块当最小值大于0时，预览值显示为0-最大值的问题
修复后预览值显示正确的最小值到最大值范围