### PR TITLE
Activate messagebox

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/Window/MessageBox.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Window/MessageBox.cs
@@ -127,6 +127,8 @@ namespace HandyControl.Controls
             }
 
             base.OnSourceInitialized(e);
+
+            Activate();
         }
 
         public override void OnApplyTemplate()


### PR DESCRIPTION
如果父窗口没有焦点，或者没有父窗口，消息框会得不到焦点。
不清楚这样改是不是合适，大佬看看。

https://user-images.githubusercontent.com/1972649/114499859-87d77980-9c59-11eb-8812-6bdb5bab4dc3.mp4



另外还有一个问题没有解决：系统MessageBox关闭后焦点会还原到之前的焦点窗口，但是HC的消息框关闭之后焦点不会还原，这时候输入文字会跑到这里：
![image](https://user-images.githubusercontent.com/1972649/114500006-d71daa00-9c59-11eb-9e9c-d7cdc7167f71.png)


