### PR TITLE
PropertyGrid和ColorPicker

### DIFF
--- a/src/Shared/HandyControlDemo_Shared/Data/Model/PropertyGridDemoModel.cs
+++ b/src/Shared/HandyControlDemo_Shared/Data/Model/PropertyGridDemoModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Windows;
 using System.Windows.Media;
+using HandyControl.Controls;
 
 namespace HandyControlDemo.Data
 {
@@ -23,11 +24,36 @@ namespace HandyControlDemo.Data
         public VerticalAlignment VerticalAlignment { get; set; }
 
         public ImageSource ImageSource { get; set; }
+
+        //[Editor(typeof(ColorPickerEditor), typeof(PropertyEditorBase))]
+        //public SolidColorBrush Color { get; set; }
+
+        //public SolidColorBrush Brush { get; set; }
+    }
+
+    public class ColorPickerEditor : PropertyEditorBase
+    {
+        public override FrameworkElement CreateElement(PropertyItem propertyItem)
+        {
+            return new ColorPicker()
+            {
+                Style = HandyControl.Tools.ResourceHelper.GetResource<Style>("ColorPickerBaseStyle"),
+                HorizontalAlignment = HorizontalAlignment.Left,
+                IsEnabled = !propertyItem.IsReadOnly
+            };
+        }
+
+        public override DependencyProperty GetDependencyProperty()
+        {
+            return ColorPicker.SelectedBrushProperty;
+        }
     }
 
     public enum Gender
     {
+        [Description("男性")]
         Male,
+        [Description("女性")]
         Female
     }
 }

--- a/src/Shared/HandyControl_Shared/Controls/ColorPicker/ColorPicker.cs
+++ b/src/Shared/HandyControl_Shared/Controls/ColorPicker/ColorPicker.cs
@@ -268,6 +268,17 @@ namespace HandyControl.Controls
                     }
                     ctl.UpdateStatus(v.Color);
                     ctl.SelectedBrushWithoutOpacity = new SolidColorBrush(Color.FromRgb(v.Color.R, v.Color.G, v.Color.B));
+                },
+                (o, value) =>
+                {
+                    if (!(value is SolidColorBrush))
+                    {
+                        return Brushes.White;
+                    }
+                    else
+                    {
+                        return value;
+                    }
                 }));
 
         /// <summary>

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/Editors/EnumPropertyEditor.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/Editors/EnumPropertyEditor.cs
@@ -1,6 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Reflection;
 using System.Windows;
 using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+using System.Linq;
 
 namespace HandyControl.Controls
 {
@@ -9,9 +15,69 @@ namespace HandyControl.Controls
         public override FrameworkElement CreateElement(PropertyItem propertyItem) => new System.Windows.Controls.ComboBox
         {
             IsEnabled = !propertyItem.IsReadOnly,
-            ItemsSource = Enum.GetValues(propertyItem.PropertyType)
+            ItemsSource = GetEnumDescription(propertyItem.PropertyType),
         };
 
         public override DependencyProperty GetDependencyProperty() => Selector.SelectedValueProperty;
+
+        protected override IValueConverter GetConverter(PropertyItem propertyItem) => new EnumDescriptionConverter(propertyItem.PropertyType);
+
+        private string[] GetEnumDescription(Type enumType)
+        {
+            var values = Enum.GetValues(enumType);
+            var enumDescs = new string[values.Length];
+            for (var i = 0; i < values.Length; i++)
+            {
+                var fi = enumType.GetField(values.GetValue(i).ToString());
+                var attrs = fi.GetCustomAttributes(typeof(DescriptionAttribute), false);
+                if (attrs.Length > 0)
+                {
+                    enumDescs[i] = ((DescriptionAttribute) attrs[0]).Description;
+                }
+                else
+                {
+                    enumDescs[i] = fi.Name;
+                }
+            }
+            return enumDescs;
+        }
+
+        private class EnumDescriptionConverter : IValueConverter
+        {
+            private readonly List<KeyValuePair<Enum, string>> cache;
+
+            public EnumDescriptionConverter(Type enumType)
+            {
+                var values = Enum.GetValues(enumType);
+                cache = new List<KeyValuePair<Enum, string>>(values.Length);
+                for (var i = 0; i < values.Length; i++)
+                {
+                    var fi = enumType.GetField(values.GetValue(i).ToString());
+                    var attrs = fi.GetCustomAttributes(typeof(DescriptionAttribute), false);
+                    if (attrs.Length > 0)
+                    {
+                        cache.Add(new KeyValuePair<Enum, string>((Enum) values.GetValue(i), ((DescriptionAttribute) attrs[0]).Description));
+                    }
+                    else
+                    {
+                        cache.Add(new KeyValuePair<Enum, string>((Enum) values.GetValue(i), fi.Name));
+                    }
+                }
+            }
+
+            object IValueConverter.Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            {
+                var myEnum = (Enum)value;
+                var pair = cache.First(x => x.Key.Equals(myEnum));
+                return pair.Value;
+            }
+
+            object IValueConverter.ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            {
+                var enumStr = (string)value;
+                var pair = cache.First(x => x.Value == enumStr);
+                return pair.Key;
+            }
+        }
     }
 }

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyResolver.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyResolver.cs
@@ -102,7 +102,7 @@ namespace HandyControl.Controls
                     ? (PropertyEditorBase) new EnumPropertyEditor()
                     : new ReadOnlyTextPropertyEditor();
 
-        public virtual PropertyEditorBase CreateEditor(Type type) => new ReadOnlyTextPropertyEditor();
+        public virtual PropertyEditorBase CreateEditor(Type type) => Activator.CreateInstance(type) as PropertyEditorBase ?? new ReadOnlyTextPropertyEditor();
 
         private enum EditorTypeCode
         {


### PR DESCRIPTION
1.增强PropertyGrid对Enum的支持，可以显示出Enum的DescriptionAttribute

2.PropertyGrid的Resolver开放自定义Editor

3.ColorPicker防止SelectedBrush赋值为空时候出现异常