### PR TITLE
PropertyGrid: Fix custom editor support

### DIFF
--- a/src/Net_40/HandyControl_Net_40/Themes/Theme.xaml
+++ b/src/Net_40/HandyControl_Net_40/Themes/Theme.xaml
@@ -9677,18 +9677,26 @@
 								<RowDefinition Height="Auto" />
 								<RowDefinition />
 							</Grid.RowDefinitions>
-							<DockPanel LastChildFill="True" Margin="0,0,0,6">
-								<hc:ButtonGroup Margin="0,0,6,0" Visibility="{Binding ShowSortButton,RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource Boolean2VisibilityConverter}}" Style="{StaticResource ButtonGroupSolid}">
-									<RadioButton Command="interactivity:ControlCommands.SortByCategory" IsChecked="True">
-										<Rectangle Width="16" Height="16" Fill="{StaticResource SortByCategoryDrawingBrush}" />
-									</RadioButton>
-									<RadioButton Command="interactivity:ControlCommands.SortByName">
-										<Rectangle Width="16" Height="16" Fill="{StaticResource SortByNameDrawingBrush}" />
-									</RadioButton>
-								</hc:ButtonGroup>
-								<hc:SearchBar x:Name="PART_SearchBar" IsRealTime="True" ShowClearButton="True" Style="{StaticResource SearchBarPlus}" />
-							</DockPanel>
-							<hc:PropertyItemsControl Grid.Row="1" x:Name="PART_ItemsControl" Style="{StaticResource PropertyItemsControlBaseStyle}">
+                            <DockPanel LastChildFill="True" Margin="0,0,0,6">
+                                <DockPanel.Visibility>
+                                    <MultiBinding Converter="{StaticResource BooleanArr2VisibilityConverter}"
+                                                  ConverterParameter="UseAny">
+                                        <Binding Path="ShowSortButton" RelativeSource="{RelativeSource TemplatedParent}" />
+                                        <Binding Path="ShowSearchBar" RelativeSource="{RelativeSource TemplatedParent}" />
+                                    </MultiBinding>
+                                </DockPanel.Visibility>
+                                <hc:ButtonGroup Margin="0,0,6,0" Visibility="{Binding ShowSortButton,RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource Boolean2VisibilityConverter}}" Style="{StaticResource ButtonGroupSolid}">
+                                    <RadioButton Command="interactivity:ControlCommands.SortByCategory" IsChecked="True">
+                                        <Rectangle Width="16" Height="16" Fill="{StaticResource SortByCategoryDrawingBrush}" />
+                                    </RadioButton>
+                                    <RadioButton Command="interactivity:ControlCommands.SortByName">
+                                        <Rectangle Width="16" Height="16" Fill="{StaticResource SortByNameDrawingBrush}" />
+                                    </RadioButton>
+                                </hc:ButtonGroup>
+                                <hc:SearchBar x:Name="PART_SearchBar" IsRealTime="True" ShowClearButton="True" Style="{StaticResource SearchBarPlus}"
+                                              Visibility="{Binding ShowSearchBar, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource Boolean2VisibilityConverter}}" />
+                            </DockPanel>
+                            <hc:PropertyItemsControl Grid.Row="1" x:Name="PART_ItemsControl" Style="{StaticResource PropertyItemsControlBaseStyle}">
 								<hc:PropertyItemsControl.GroupStyle>
 									<GroupStyle ContainerStyle="{StaticResource PropertyGroupItemBaseStyle}" />
 								</hc:PropertyItemsControl.GroupStyle>

--- a/src/Net_40/HandyControl_Net_40/Themes/Theme.xaml
+++ b/src/Net_40/HandyControl_Net_40/Themes/Theme.xaml
@@ -697,8 +697,16 @@
 				<GeometryDrawing o:Freeze="True" Brush="#FF00529C" Geometry="F1M15,8L15,10 12,13 9,10 9,8 11,10 11,4 13,4 13,10z" />
 			</DrawingGroup>
 		</DrawingBrush.Drawing>
-	</DrawingBrush>
-	<ItemsPanelTemplate x:Key="StepBarHorizontalItemsPanelTemplate">
+    </DrawingBrush>
+    <DrawingBrush x:Key="SortByHierarchyLevelDrawingBrush" o:Freeze="True">
+        <DrawingBrush.Drawing>
+            <DrawingGroup o:Freeze="True">
+                <GeometryDrawing o:Freeze="True" Brush="#FF000000" Geometry="F1 M470,470z M0,0z M346.494,283.658L346.494,358.951 296.758,358.951 296.758,283.658 245,283.658 245,186.343 296.758,186.343 296.758,0 173.242,0 173.242,186.343 225,186.343 225,283.658 173.242,283.658 173.242,358.951 123.516,358.951 123.516,283.658 0,283.658 0,470 123.516,470 123.516,378.951 173.242,378.951 173.242,470 296.758,470 296.758,378.951 346.494,378.951 346.494,470 470,470 470,283.658 346.494,283.658z M193.242,20L276.758,20 276.758,166.343 193.242,166.343 193.242,20z M103.516,450L20,450 20,303.658 103.516,303.658 103.516,450z M276.758,450L193.242,450 193.242,303.658 276.758,303.658 276.758,450z M450,450L366.494,450 366.494,303.658 450,303.658 450,450z" />
+            </DrawingGroup>
+        </DrawingBrush.Drawing>
+    </DrawingBrush>
+
+    <ItemsPanelTemplate x:Key="StepBarHorizontalItemsPanelTemplate">
 		<UniformGrid Rows="1" />
 	</ItemsPanelTemplate>
 	<ItemsPanelTemplate x:Key="StepBarVerticalItemsPanelTemplate">
@@ -9691,6 +9699,9 @@
                                     </RadioButton>
                                     <RadioButton Command="interactivity:ControlCommands.SortByName">
                                         <Rectangle Width="16" Height="16" Fill="{StaticResource SortByNameDrawingBrush}" />
+                                    </RadioButton>
+                                    <RadioButton Command="interactivity:ControlCommands.SortByHierarchyLevel">
+                                        <Rectangle Width="16" Height="16" Fill="{StaticResource SortByHierarchyLevelDrawingBrush}" />
                                     </RadioButton>
                                 </hc:ButtonGroup>
                                 <hc:SearchBar x:Name="PART_SearchBar" IsRealTime="True" ShowClearButton="True" Style="{StaticResource SearchBarPlus}"

--- a/src/Shared/HandyControlDemo_Shared/Data/Model/PropertyGridDemoModel.cs
+++ b/src/Shared/HandyControlDemo_Shared/Data/Model/PropertyGridDemoModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Windows;
 using System.Windows.Media;
+using HandyControl.Controls;
 
 namespace HandyControlDemo.Data
 {
@@ -20,6 +21,10 @@ namespace HandyControlDemo.Data
 
         [Category("Category2")]
         public DemoDataModel FlattenedType { get; set; }
+
+        [Category("Category1")]
+        [HierarchyLevel(0)]
+        public DemoDataModel LowHierarchy { get; set; }
 
         public HorizontalAlignment HorizontalAlignment { get; set; }
 

--- a/src/Shared/HandyControlDemo_Shared/Data/Model/PropertyGridDemoModel.cs
+++ b/src/Shared/HandyControlDemo_Shared/Data/Model/PropertyGridDemoModel.cs
@@ -1,7 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Windows;
 using System.Windows.Media;
-using HandyControl.Controls;
 
 namespace HandyControlDemo.Data
 {

--- a/src/Shared/HandyControlDemo_Shared/Data/Model/PropertyGridDemoModel.cs
+++ b/src/Shared/HandyControlDemo_Shared/Data/Model/PropertyGridDemoModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Windows;
 using System.Windows.Media;
+using HandyControl.Controls;
 
 namespace HandyControlDemo.Data
 {
@@ -17,6 +18,9 @@ namespace HandyControlDemo.Data
 
         [Category("Category1")]
         public Gender Enum { get; set; }
+
+        [Category("Category2")]
+        public DemoDataModel FlattenedType { get; set; }
 
         public HorizontalAlignment HorizontalAlignment { get; set; }
 

--- a/src/Shared/HandyControlDemo_Shared/UserControl/Controls/PropertyGridDemoCtl.xaml
+++ b/src/Shared/HandyControlDemo_Shared/UserControl/Controls/PropertyGridDemoCtl.xaml
@@ -10,7 +10,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <hc:PropertyGrid Width="500" SelectedObject="{Binding DemoModel}"/>
+            <hc:PropertyGrid Width="500" SelectedObject="{Binding DemoModel}" FlattenChildProperties="ParentNameAsCategory"/>
             <StackPanel hc:TitleElement.TitleWidth="168" Grid.Row="1" Margin="20,16,17,10">
                 <TextBox hc:TitleElement.Title="String" hc:TitleElement.TitlePlacement="Left" Style="{StaticResource TextBoxExtend}" Text="{Binding DemoModel.String,Mode=OneWay}" IsReadOnly="True"/>
                 <TextBox hc:TitleElement.Title="Enum" hc:TitleElement.TitlePlacement="Left" Style="{StaticResource TextBoxExtend}" Text="{Binding DemoModel.Enum,Mode=OneWay}" IsReadOnly="True" Margin="0,6,0,0"/>

--- a/src/Shared/HandyControlDemo_Shared/UserControl/Controls/PropertyGridDemoCtl.xaml.cs
+++ b/src/Shared/HandyControlDemo_Shared/UserControl/Controls/PropertyGridDemoCtl.xaml.cs
@@ -11,11 +11,12 @@ namespace HandyControlDemo.UserControl
 
             DemoModel = new PropertyGridDemoModel
             {
-                String = "TestString",
-                Enum = Gender.Female,
-                Boolean = true,
-                Integer = 98,
-                VerticalAlignment = VerticalAlignment.Stretch
+                String            = "TestString",
+                Enum              = Gender.Female,
+                Boolean           = true,
+                Integer           = 98,
+                VerticalAlignment = VerticalAlignment.Stretch,
+                FlattenedType     = new DemoDataModel {Index = 0, IsSelected = true, Name = "Flattened", Remark = "Remark", Type = DemoType.Type4}
             };
         }
 

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyGrid.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -138,34 +139,38 @@ namespace HandyControl.Controls
         /// </summary>
         private class ParentPropertyDescriptorCollection
         {
-            public ParentPropertyDescriptorCollection(PropertyDescriptorCollection properties, string category)
+            public ParentPropertyDescriptorCollection(PropertyDescriptorCollection properties, object parent, string category)
             {
                 Properties = properties;
                 Category = category;
+                ParentComponent = parent;
             }
 
             public PropertyDescriptorCollection Properties { get; }
             public string Category { get; }
+            public object ParentComponent { get; }
         }
 
-        private IEnumerable<PropertyItem> FlattenUnknownProperties(PropertyDescriptorCollection propertiesToFlatten, string parentCategory)
+        private IEnumerable<PropertyItem> FlattenUnknownProperties(ParentPropertyDescriptorCollection collection) =>
+            FlattenUnknownProperties(collection.Properties, collection.ParentComponent, collection.Category);
+
+        private IEnumerable<PropertyItem> FlattenUnknownProperties(IEnumerable propertiesToFlatten, object component, string parentCategory)
         {
             var browsableProperties = propertiesToFlatten.OfType<PropertyDescriptor>()
                                                          .Where(item => PropertyResolver.ResolveIsBrowsable(item)).ToList();
 
             var knownProperties = browsableProperties.Where(item => PropertyResolver.IsKnownEditorType(item.PropertyType))
-                                                     .Select(item => CreatePropertyItem(item, parentCategory))
+                                                     .Select(item => CreatePropertyItem(item, component, parentCategory))
                                                      .Do(item => item.InitElement());
 
             var unknownPropertiesCollections = browsableProperties.Where(item => !PropertyResolver.IsKnownEditorType(item.PropertyType))
-                                                                  .Select(GetCategorizedChildProperties);
+                                                                  .Select(item => GetCategorizedChildProperties(item, component));
 
-            return unknownPropertiesCollections
-                   .Select(coll => FlattenUnknownProperties(coll.Properties, coll.Category))
-                   .Aggregate(knownProperties, (current, flattenedChildProperties) => current.Concat(flattenedChildProperties));
+            return unknownPropertiesCollections.Select(FlattenUnknownProperties)
+                                               .Aggregate(knownProperties, (current, flattenedChildProperties) => current.Concat(flattenedChildProperties));
         }
 
-        private ParentPropertyDescriptorCollection GetCategorizedChildProperties(PropertyDescriptor parentItem)
+        private ParentPropertyDescriptorCollection GetCategorizedChildProperties(PropertyDescriptor parentItem, object parentComponent)
         {
             string category = null;
             switch (FlattenChildProperties)
@@ -177,7 +182,7 @@ namespace HandyControl.Controls
                     category = parentItem.DisplayName;
                     break;
             }
-            return new ParentPropertyDescriptorCollection(parentItem.GetChildProperties(), category);
+            return new ParentPropertyDescriptorCollection(parentItem.GetChildProperties(), parentItem.GetValue(parentComponent), category);
         }
 
         private void UpdateItems(object obj)
@@ -189,12 +194,12 @@ namespace HandyControl.Controls
                 _dataView = CollectionViewSource.GetDefaultView(TypeDescriptor.GetProperties(obj.GetType())
                                                                               .OfType<PropertyDescriptor>()
                                                                               .Where(item => PropertyResolver.ResolveIsBrowsable(item))
-                                                                              .Select(item => CreatePropertyItem(item, null))
+                                                                              .Select(item => CreatePropertyItem(item, obj, null))
                                                                               .Do(item => item.InitElement()));
             }
             else
             {
-                _dataView = CollectionViewSource.GetDefaultView(FlattenUnknownProperties(TypeDescriptor.GetProperties(obj.GetType()), null));
+                _dataView = CollectionViewSource.GetDefaultView(FlattenUnknownProperties(TypeDescriptor.GetProperties(obj.GetType()), obj, null));
             }
 
             SortByCategory(null, null);
@@ -249,7 +254,7 @@ namespace HandyControl.Controls
             }
         }
 
-        protected virtual PropertyItem CreatePropertyItem(PropertyDescriptor propertyDescriptor, string category) =>
+        protected virtual PropertyItem CreatePropertyItem(PropertyDescriptor propertyDescriptor, object component, string category) =>
             new PropertyItem
             {
                 Category         = category ?? PropertyResolver.ResolveCategory(propertyDescriptor),
@@ -258,7 +263,7 @@ namespace HandyControl.Controls
                 IsReadOnly       = PropertyResolver.ResolveIsReadOnly(propertyDescriptor),
                 DefaultValue     = PropertyResolver.ResolveDefaultValue(propertyDescriptor),
                 Editor           = PropertyResolver.ResolveEditor(propertyDescriptor),
-                Value            = SelectedObject,
+                Value            = component,
                 PropertyName     = propertyDescriptor.Name,
                 PropertyType     = propertyDescriptor.PropertyType,
                 PropertyTypeName = $"{propertyDescriptor.PropertyType.Namespace}.{propertyDescriptor.PropertyType.Name}"

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyGrid.cs
@@ -102,6 +102,15 @@ namespace HandyControl.Controls
             set => SetValue(ShowSortButtonProperty, value);
         }
 
+        public static readonly DependencyProperty ShowSearchBarProperty = DependencyProperty.Register(
+            "ShowSearchBar", typeof(bool), typeof(PropertyGrid), new PropertyMetadata(ValueBoxes.TrueBox));
+
+        public bool ShowSearchBar
+        {
+            get => (bool) GetValue(ShowSearchBarProperty);
+            set => SetValue(ShowSearchBarProperty, value);
+        }
+
         public override void OnApplyTemplate()
         {
             if (_searchBar != null)

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyItem.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyItem.cs
@@ -116,6 +116,15 @@ namespace HandyControl.Controls
             set => SetValue(IsExpandedEnabledProperty, ValueBoxes.BooleanBox(value));
         }
 
+        public static readonly DependencyProperty HierarchyLevelProperty = DependencyProperty.Register(
+         "HierarchyLevel", typeof(int?), typeof(PropertyItem), new PropertyMetadata(default(int?)));
+
+        public int? HierarchyLevel
+        {
+            get => (int?) GetValue(HierarchyLevelProperty);
+            set => SetValue(HierarchyLevelProperty, value);
+        }
+
         public PropertyDescriptor PropertyDescriptor { get; set; }
 
         public virtual void InitElement()

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyResolver.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyResolver.cs
@@ -116,7 +116,7 @@ namespace HandyControl.Controls
                     : new ReadOnlyTextPropertyEditor();
         }
 
-        public virtual PropertyEditorBase CreateEditor(Type type) => new ReadOnlyTextPropertyEditor();
+        public virtual PropertyEditorBase CreateEditor(Type type) => Activator.CreateInstance(type) as PropertyEditorBase ?? new ReadOnlyTextPropertyEditor();
 
         public static bool IsKnownEditorType(Type type)
         {

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyResolver.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyResolver.cs
@@ -41,6 +41,12 @@ namespace HandyControl.Controls
                     categoryAttribute.Category;
         }
 
+        public int? ResolveHierarchyLevel(PropertyDescriptor propertyDescriptor)
+        {
+            var hierarchyLevelAttribute = propertyDescriptor.Attributes.OfType<HierarchyLevelAttribute>().FirstOrDefault();
+            return hierarchyLevelAttribute?.Value;
+        }
+
         public string ResolveDisplayName(PropertyDescriptor propertyDescriptor)
         {
             var displayName = propertyDescriptor.DisplayName;

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyResolver.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyResolver.cs
@@ -104,6 +104,8 @@ namespace HandyControl.Controls
 
         public virtual PropertyEditorBase CreateEditor(Type type) => new ReadOnlyTextPropertyEditor();
 
+        public static bool IsKnownEditorType(Type type) => TypeCodeDic.ContainsKey(type) || type.IsSubclassOf(typeof(Enum));
+
         private enum EditorTypeCode
         {
             PlainText,

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyResolver.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyResolver.cs
@@ -76,8 +76,15 @@ namespace HandyControl.Controls
             return editor;
         }
 
-        public virtual PropertyEditorBase CreateDefaultEditor(Type type) =>
-            TypeCodeDic.TryGetValue(type, out var editorType)
+        public virtual PropertyEditorBase CreateDefaultEditor(Type type)
+        {
+            var underlyingType = Nullable.GetUnderlyingType(type);
+            if (underlyingType is not null)
+            {
+                type = underlyingType;
+            }
+
+            return TypeCodeDic.TryGetValue(type, out var editorType)
                 ? editorType switch
                 {
                     EditorTypeCode.PlainText => new PlainTextPropertyEditor(),
@@ -101,10 +108,20 @@ namespace HandyControl.Controls
                 : type.IsSubclassOf(typeof(Enum))
                     ? (PropertyEditorBase) new EnumPropertyEditor()
                     : new ReadOnlyTextPropertyEditor();
+        }
 
         public virtual PropertyEditorBase CreateEditor(Type type) => new ReadOnlyTextPropertyEditor();
 
-        public static bool IsKnownEditorType(Type type) => TypeCodeDic.ContainsKey(type) || type.IsSubclassOf(typeof(Enum));
+        public static bool IsKnownEditorType(Type type)
+        {
+            var underlyingType = Nullable.GetUnderlyingType(type);
+            if (underlyingType is not null)
+            {
+                type = underlyingType;
+            }
+
+            return TypeCodeDic.ContainsKey(type) || type.IsSubclassOf(typeof(Enum));
+        }
 
         private enum EditorTypeCode
         {

--- a/src/Shared/HandyControl_Shared/Data/Annotations/HierarchyLevelAttribute.cs
+++ b/src/Shared/HandyControl_Shared/Data/Annotations/HierarchyLevelAttribute.cs
@@ -1,0 +1,94 @@
+﻿// -----------------------------
+// Copyright (c) XION GmbH
+// -----------------------------
+#nullable enable
+using System;
+
+namespace HandyControl.Controls
+{
+    [AttributeUsage(AttributeTargets.All)]
+    public class HierarchyLevelAttribute : Attribute
+    {
+        /// <summary>
+        /// This is the hierarchy level value.
+        /// </summary>
+        private int? _value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='HierarchyLevelAttribute'/>
+        /// class using a Unicode character.
+        /// </summary>
+        public HierarchyLevelAttribute(char value)
+        {
+            _value = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='HierarchyLevelAttribute'/>
+        /// class using an 8-bit unsigned integer.
+        /// </summary>
+        public HierarchyLevelAttribute(byte value)
+        {
+            _value = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='HierarchyLevelAttribute'/>
+        /// class using a 16-bit signed integer.
+        /// </summary>
+        public HierarchyLevelAttribute(short value)
+        {
+            _value = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='HierarchyLevelAttribute'/>
+        /// class using a 32-bit signed integer.
+        /// </summary>
+        public HierarchyLevelAttribute(int value)
+        {
+            _value = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='HierarchyLevelAttribute'/>
+        /// class using a <see cref='System.String'/>.
+        /// </summary>
+        public HierarchyLevelAttribute(string? value)
+        {
+            if (value is null || !int.TryParse(value, out var val))
+            {
+                return;
+            }
+            _value = val;
+        }
+
+        /// <summary>
+        /// Gets the default value of the property this attribute is bound to.
+        /// </summary>
+        public virtual int? Value => _value;
+
+        public override bool Equals(object? obj)
+        {
+            if (obj == this)
+            {
+                return true;
+            }
+            if (!(obj is HierarchyLevelAttribute other))
+            {
+                return false;
+            }
+
+            if (Value == null)
+            {
+                return other.Value == null;
+            }
+
+            return Value.Equals(other.Value);
+        }
+
+        public override int GetHashCode() => base.GetHashCode();
+
+        protected void SetValue(int? value) => _value = value;
+    }
+}

--- a/src/Shared/HandyControl_Shared/Data/Enum/Flattening.cs
+++ b/src/Shared/HandyControl_Shared/Data/Enum/Flattening.cs
@@ -1,0 +1,14 @@
+﻿// -----------------------------
+// Copyright (c) XION GmbH
+// -----------------------------
+
+namespace HandyControl.Data.Enum
+{
+    public enum Flattening : byte
+    {
+        Off,
+        Uncategorized,
+        ParentCategory,
+        ParentNameAsCategory
+    }
+}

--- a/src/Shared/HandyControl_Shared/HandyControl_Shared.projitems
+++ b/src/Shared/HandyControl_Shared/HandyControl_Shared.projitems
@@ -80,6 +80,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Text\SimpleText.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Window\GlowWindow.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Collections\DateTimeRangeComparer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Data\Annotations\HierarchyLevelAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Data\Enum\Flattening.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Data\Enum\VisualWrapping.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Data\Flex\FlexContentJustify.cs" />

--- a/src/Shared/HandyControl_Shared/HandyControl_Shared.projitems
+++ b/src/Shared/HandyControl_Shared/HandyControl_Shared.projitems
@@ -80,6 +80,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Text\SimpleText.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Window\GlowWindow.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Collections\DateTimeRangeComparer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Data\Enum\Flattening.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Data\Enum\VisualWrapping.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Data\Flex\FlexContentJustify.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Data\Flex\FlexContentAlignment.cs" />

--- a/src/Shared/HandyControl_Shared/Interactivity/Commands/ControlCommands.cs
+++ b/src/Shared/HandyControl_Shared/Interactivity/Commands/ControlCommands.cs
@@ -181,5 +181,10 @@ namespace HandyControl.Interactivity
         ///     按照名称排序
         /// </summary>
         public static RoutedCommand SortByName { get; } = new RoutedCommand(nameof(SortByName), typeof(ControlCommands));
+
+        /// <summary>
+        ///
+        /// </summary>
+        public static RoutedCommand SortByHierarchyLevel { get; } = new RoutedCommand(nameof(SortByHierarchyLevel), typeof(ControlCommands));
     }
 }

--- a/src/Shared/HandyControl_Shared/Themes/Styles/Base/PropertyGridBaseStyle.xaml
+++ b/src/Shared/HandyControl_Shared/Themes/Styles/Base/PropertyGridBaseStyle.xaml
@@ -141,6 +141,13 @@
                                 <RowDefinition/>
                             </Grid.RowDefinitions>
                             <DockPanel LastChildFill="True" Margin="0,0,0,6">
+                                <DockPanel.Visibility>
+                                    <MultiBinding Converter="{StaticResource BooleanArr2VisibilityConverter}"
+                                                  ConverterParameter="UseAny">
+                                        <Binding Path="ShowSortButton" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                        <Binding Path="ShowSearchBar" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                    </MultiBinding>
+                                </DockPanel.Visibility>
                                 <hc:ButtonGroup Margin="0,0,6,0" Visibility="{Binding ShowSortButton,RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource Boolean2VisibilityConverter}}" Style="{StaticResource ButtonGroupSolid}">
                                     <RadioButton Command="interactivity:ControlCommands.SortByCategory" IsChecked="True">
                                         <Rectangle Width="16" Height="16" Fill="{StaticResource SortByCategoryDrawingBrush}"/>
@@ -149,7 +156,8 @@
                                         <Rectangle Width="16" Height="16" Fill="{StaticResource SortByNameDrawingBrush}"/>
                                     </RadioButton>
                                 </hc:ButtonGroup>
-                                <hc:SearchBar x:Name="PART_SearchBar" IsRealTime="True" ShowClearButton="True" Style="{StaticResource SearchBarPlus}"/>
+                                <hc:SearchBar x:Name="PART_SearchBar" IsRealTime="True" ShowClearButton="True" Style="{StaticResource SearchBarPlus}"
+                                              Visibility="{Binding ShowSearchBar,RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource Boolean2VisibilityConverter}}"/>
                             </DockPanel>
                             <hc:PropertyItemsControl Grid.Row="1" x:Name="PART_ItemsControl" Style="{StaticResource PropertyItemsControlBaseStyle}">
                                 <hc:PropertyItemsControl.GroupStyle>

--- a/src/Shared/HandyControl_Shared/Themes/Styles/Base/PropertyGridBaseStyle.xaml
+++ b/src/Shared/HandyControl_Shared/Themes/Styles/Base/PropertyGridBaseStyle.xaml
@@ -36,6 +36,14 @@
         </DrawingBrush.Drawing>
     </DrawingBrush>
 
+    <DrawingBrush x:Key="SortByHierarchyLevelDrawingBrush" o:Freeze="True">
+        <DrawingBrush.Drawing>
+            <DrawingGroup o:Freeze="True">
+                <GeometryDrawing o:Freeze="True" Brush="#FF000000" Geometry="F1 M470,470z M0,0z M346.494,283.658L346.494,358.951 296.758,358.951 296.758,283.658 245,283.658 245,186.343 296.758,186.343 296.758,0 173.242,0 173.242,186.343 225,186.343 225,283.658 173.242,283.658 173.242,358.951 123.516,358.951 123.516,283.658 0,283.658 0,470 123.516,470 123.516,378.951 173.242,378.951 173.242,470 296.758,470 296.758,378.951 346.494,378.951 346.494,470 470,470 470,283.658 346.494,283.658z M193.242,20L276.758,20 276.758,166.343 193.242,166.343 193.242,20z M103.516,450L20,450 20,303.658 103.516,303.658 103.516,450z M276.758,450L193.242,450 193.242,303.658 276.758,303.658 276.758,450z M450,450L366.494,450 366.494,303.658 450,303.658 450,450z" />
+            </DrawingGroup>
+        </DrawingBrush.Drawing>
+    </DrawingBrush>
+
     <Style x:Key="PropertyItemToolTipBaseStyle" BasedOn="{StaticResource {x:Type ToolTip}}" TargetType="ToolTip">
         <Setter Property="Padding" Value="10"/>
         <Setter Property="hc:BorderElement.CornerRadius" Value="2"/>
@@ -154,6 +162,9 @@
                                     </RadioButton>
                                     <RadioButton Command="interactivity:ControlCommands.SortByName">
                                         <Rectangle Width="16" Height="16" Fill="{StaticResource SortByNameDrawingBrush}"/>
+                                    </RadioButton>
+                                    <RadioButton Command="interactivity:ControlCommands.SortByHierarchyLevel">
+                                        <Rectangle Width="16" Height="16" Fill="{StaticResource SortByHierarchyLevelDrawingBrush}" />
                                     </RadioButton>
                                 </hc:ButtonGroup>
                                 <hc:SearchBar x:Name="PART_SearchBar" IsRealTime="True" ShowClearButton="True" Style="{StaticResource SearchBarPlus}"

--- a/src/Shared/HandyControl_Shared/Themes/Theme.xaml
+++ b/src/Shared/HandyControl_Shared/Themes/Theme.xaml
@@ -698,6 +698,13 @@
 			</DrawingGroup>
 		</DrawingBrush.Drawing>
 	</DrawingBrush>
+	<DrawingBrush x:Key="SortByHierarchyLevelDrawingBrush" o:Freeze="True">
+		<DrawingBrush.Drawing>
+			<DrawingGroup o:Freeze="True">
+				<GeometryDrawing o:Freeze="True" Brush="#FF000000" Geometry="F1 M470,470z M0,0z M346.494,283.658L346.494,358.951 296.758,358.951 296.758,283.658 245,283.658 245,186.343 296.758,186.343 296.758,0 173.242,0 173.242,186.343 225,186.343 225,283.658 173.242,283.658 173.242,358.951 123.516,358.951 123.516,283.658 0,283.658 0,470 123.516,470 123.516,378.951 173.242,378.951 173.242,470 296.758,470 296.758,378.951 346.494,378.951 346.494,470 470,470 470,283.658 346.494,283.658z M193.242,20L276.758,20 276.758,166.343 193.242,166.343 193.242,20z M103.516,450L20,450 20,303.658 103.516,303.658 103.516,450z M276.758,450L193.242,450 193.242,303.658 276.758,303.658 276.758,450z M450,450L366.494,450 366.494,303.658 450,303.658 450,450z" />
+			</DrawingGroup>
+		</DrawingBrush.Drawing>
+	</DrawingBrush>
 	<ItemsPanelTemplate x:Key="StepBarHorizontalItemsPanelTemplate">
 		<UniformGrid Rows="1" />
 	</ItemsPanelTemplate>
@@ -9808,6 +9815,9 @@
 									</RadioButton>
 									<RadioButton Command="interactivity:ControlCommands.SortByName">
 										<Rectangle Width="16" Height="16" Fill="{StaticResource SortByNameDrawingBrush}" />
+									</RadioButton>
+									<RadioButton Command="interactivity:ControlCommands.SortByHierarchyLevel">
+										<Rectangle Width="16" Height="16" Fill="{StaticResource SortByHierarchyLevelDrawingBrush}" />
 									</RadioButton>
 								</hc:ButtonGroup>
 								<hc:SearchBar x:Name="PART_SearchBar" IsRealTime="True" ShowClearButton="True" Style="{StaticResource SearchBarPlus}" Visibility="{Binding ShowSearchBar,RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource Boolean2VisibilityConverter}}" />

--- a/src/Shared/HandyControl_Shared/Themes/Theme.xaml
+++ b/src/Shared/HandyControl_Shared/Themes/Theme.xaml
@@ -9796,6 +9796,12 @@
 								<RowDefinition />
 							</Grid.RowDefinitions>
 							<DockPanel LastChildFill="True" Margin="0,0,0,6">
+								<DockPanel.Visibility>
+									<MultiBinding Converter="{StaticResource BooleanArr2VisibilityConverter}" ConverterParameter="UseAny">
+										<Binding Path="ShowSortButton" RelativeSource="{RelativeSource TemplatedParent}" />
+										<Binding Path="ShowSearchBar" RelativeSource="{RelativeSource TemplatedParent}" />
+									</MultiBinding>
+								</DockPanel.Visibility>
 								<hc:ButtonGroup Margin="0,0,6,0" Visibility="{Binding ShowSortButton,RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource Boolean2VisibilityConverter}}" Style="{StaticResource ButtonGroupSolid}">
 									<RadioButton Command="interactivity:ControlCommands.SortByCategory" IsChecked="True">
 										<Rectangle Width="16" Height="16" Fill="{StaticResource SortByCategoryDrawingBrush}" />
@@ -9804,7 +9810,7 @@
 										<Rectangle Width="16" Height="16" Fill="{StaticResource SortByNameDrawingBrush}" />
 									</RadioButton>
 								</hc:ButtonGroup>
-								<hc:SearchBar x:Name="PART_SearchBar" IsRealTime="True" ShowClearButton="True" Style="{StaticResource SearchBarPlus}" />
+								<hc:SearchBar x:Name="PART_SearchBar" IsRealTime="True" ShowClearButton="True" Style="{StaticResource SearchBarPlus}" Visibility="{Binding ShowSearchBar,RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource Boolean2VisibilityConverter}}" />
 							</DockPanel>
 							<hc:PropertyItemsControl Grid.Row="1" x:Name="PART_ItemsControl" Style="{StaticResource PropertyItemsControlBaseStyle}">
 								<hc:PropertyItemsControl.GroupStyle>

--- a/src/Shared/HandyControl_Shared/Tools/Converter/BooleanArr2VisibilityConverter.cs
+++ b/src/Shared/HandyControl_Shared/Tools/Converter/BooleanArr2VisibilityConverter.cs
@@ -28,6 +28,10 @@ namespace HandyControl.Tools.Converter
                     return Visibility.Collapsed;
                 }
             }
+            if (parameter is string useAny && useAny == "UseAny")
+            {
+                return arr.Any(item => item) ? Visibility.Visible : Visibility.Collapsed;
+            }
             return arr.All(item => item) ? Visibility.Visible : Visibility.Collapsed;
         }
 


### PR DESCRIPTION
Custom editors were not created for unknown property types but only the default editor.