### PR TITLE
fix  glowl fetal when caller GrowlPanel.ContextMenu before GrowlPanel…

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/Growl/Growl.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Growl/Growl.cs
@@ -775,6 +775,7 @@ namespace HandyControl.Controls
         /// <param name="growlInfo"></param>
         public static void Fatal(GrowlInfo growlInfo)
         {
+            GrowlPanel ??= CreateDefaultPanel();
             InitGrowlInfo(ref growlInfo, InfoType.Fatal);
             Show(growlInfo);
         }


### PR DESCRIPTION
… init caused NullReferenceException  
close #848