### PR TITLE
PropertyGrid: simple handling of custom editors

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyResolver.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyResolver.cs
@@ -102,7 +102,7 @@ namespace HandyControl.Controls
                     ? (PropertyEditorBase) new EnumPropertyEditor()
                     : new ReadOnlyTextPropertyEditor();
 
-        public virtual PropertyEditorBase CreateEditor(Type type) => new ReadOnlyTextPropertyEditor();
+        public virtual PropertyEditorBase CreateEditor(Type type) => Activator.CreateInstance(type) as PropertyEditorBase ?? new ReadOnlyTextPropertyEditor();
 
         private enum EditorTypeCode
         {


### PR DESCRIPTION
_In PropertyResolver, CreateEditor() uses the provided type or falls back to previous behavior_

Hi, many thanks for this great project!
I really need this functionality as there is no current workaround, because we can't subclass PropertyGrid for some reason (#812). 

![customEditors](https://user-images.githubusercontent.com/16904907/120891268-edb40200-c607-11eb-8cf9-ba27e5491eb2.png)
This capture is from a Proof-Of-Concept branch [here](https://github.com/ChoKaPeek/HandyControl/tree/poc-custom-editors).