### PR TITLE
修复当使用 Dialog 展示，当主窗体为非活动窗口时，调用 Close 方法无法自动关闭的问题

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/Dialog/Dialog.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Dialog/Dialog.cs
@@ -110,7 +110,7 @@ namespace HandyControl.Controls
             AdornerDecorator decorator;
             if (string.IsNullOrEmpty(token))
             {
-                element = WindowHelper.GetActiveWindow();
+                element = WindowHelper.GetActiveWindow() ?? Application.Current.MainWindow;
                 decorator = VisualHelper.GetChild<AdornerDecorator>(element);
             }
             else
@@ -147,7 +147,7 @@ namespace HandyControl.Controls
         {
             if (string.IsNullOrEmpty(_token))
             {
-                Close(WindowHelper.GetActiveWindow());
+                Close(WindowHelper.GetActiveWindow() ?? Application.Current.MainWindow);
             }
             else if (ContainerDic.TryGetValue(_token, out var element))
             {


### PR DESCRIPTION
当使用 Dialog 进行 Loading 异步任务加载时，如果用户切换当前活动应用，导致该应用处于非活动状态，如果异步任务执行完毕后，调用 Close 方法无法自动关闭

示例代码
```C#
var dlg = Dialog.Show<HistoryControl>();
await Task.Run(() => { Thread.Sleep(5000); });
dlg.Close();  //如果当前程序非活动窗体时，dlg 无法正常关闭
Trace.WriteLine($"IsClosed：{dlg.IsClosed}"); 
```