### PR TITLE
Changed the project url of AutumnBox.

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -143,7 +143,7 @@ HandyControl 项目已加入 [dotNET China](https://gitee.com/dotnetchina)  组�
 
 <a href="https://getquicker.net" target="_blank"><img width="70px" alt="quicker" src="https://files.getquicker.net/_sitefiles/quicker_round_128.png"></a>
 <a href="https://www.phpenv.cn" target="_blank"><img width="70px" alt="phpenv" src="https://www.phpenv.cn/usr/themes/phpenv/img/logo.png"></a>
-<a href="https://atmb.top" target="_blank"><img width="70px" alt="AutumnBox" src="https://atmb.top/images/icon.png"></a>
+<a href="https://github.com/zsh2401/AutumnBox" target="_blank"><img width="70px" alt="AutumnBox" src="https://raw.githubusercontent.com/zsh2401/AutumnBox/master/src/AutumnBox.GUI/Resources/Icons/icon.ico"></a>
 
 如果你的项目没有被列出，请告知我们! 😀
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@
 
 <a href="https://getquicker.net" target="_blank"><img width="70px" alt="quicker" src="https://i0.hdslb.com/bfs/face/3765a3d0ce5da37e1aaa830d2eec6d3e0806a2d8.jpg@96w_96h_1c.webp"></a>
 <a href="https://www.phpenv.cn" target="_blank"><img width="70px" alt="phpenv" src="https://www.phpenv.cn/usr/themes/phpenv/img/logo.png"></a>
-<a href="https://atmb.top" target="_blank"><img width="70px" alt="AutumnBox" src="https://atmb.top/images/icon.png"></a>
+<a href="https://github.com/zsh2401/AutumnBox" target="_blank"><img width="70px" alt="AutumnBox" src="https://raw.githubusercontent.com/zsh2401/AutumnBox/master/src/AutumnBox.GUI/Resources/Icons/icon.ico"></a>
 
 if your project is not listed here, let us know! 😀
 


### PR DESCRIPTION
Due to the unstability, there are lot of people who can not access the AutumnBox's official site normally. For this reason, I changed the url of AutumnBox in README.md to its open source repo on GitHub directly.