### PR TITLE
解决编译目标为x86的情况下报错

### DIFF
--- a/src/Shared/HandyControl_Shared/Tools/Interop/InteropValues.cs
+++ b/src/Shared/HandyControl_Shared/Tools/Interop/InteropValues.cs
@@ -379,7 +379,7 @@ internal class InteropValues
             get
             {
                 WINDOWPLACEMENT result = new WINDOWPLACEMENT();
-                result.length = Marshal.SizeOf(result);
+                result.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT);
                 return result;
             }
         }


### PR DESCRIPTION
托管调试助手 "PInvokeStackImbalance":“对 PInvoke 函数“HandyControl!HandyControl.Tools.Interop.InteropMethods::GetWindowPlacement”的调用导致堆栈不对称。原因可能是托管的 PInvoke 签名与非托管的目标签名不匹配。请检查 PInvoke 签名的调用约定和参数与非托管的目标签名是否匹配。”

具体报错为情况为（HandyControl和HandyControls都同样错误）：[https://github.com/ghost1372/HandyControls/issues/183](url) 